### PR TITLE
Separate ci estimation into function; use argparse for argument parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*__pycache__
+*pyc

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ for the mutation rate `p`.
 To compute a p confidence interval from an observed number of scaled containment indices:
 
 ```bash
-p-from-scaled-containment.py -L 100K -k 21 -c 0.95 --sccon 0.10605
+python ./p-from-scaled-containment.py -L 100K -k 21 -c 0.95 --sccon 0.10605
 L       k       conf    Cks     CLow    CHigh   pLow    pHigh
 100000  21      0.95    0.10605 0.10046 0.11191 0.09623 0.10655
 ```

--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ for the mutation rate `p`.
 ### Quick start
 
 To compute a p confidence interval from an observed number of scaled containment indices:
-```bash 
-$ p-from-scaled-containment.py L=100K k=21 C=0.95 Cks=0.10605
+
+```bash
+p-from-scaled-containment.py -L 100K -k 21 -c 0.95 --sccon 0.10605
 L       k       conf    Cks     CLow    CHigh   pLow    pHigh
 100000  21      0.95    0.10605 0.10046 0.11191 0.09623 0.10655
 ```
@@ -62,26 +63,25 @@ simulate_nucleotide_errors are not available.
 
 ### Usage Details
 
-p-from-scaled-containment.py
+python p-from-scaled-containment.py
 
-```bash  
-Compute confidence interval for the mutation rate p, given the observed scaled MinHash value.
+```bash
+Compute confidence interval for the mutation rate p, given the observed number of mutated k-mers
 
-usage: p-from-scaled-containment.py [options]
-  --sccon=<list>              (Cks=) (cumulative) observed scaled MinHash
-                              value; <list> is a comma-separated list of
-                              numbers
-  --scale=<probability>       (s=) scaling factor of the hash
-  
-  --length=<N>                (l=) sequence length (number of NUCLEOTIDES in
-                              the sequence)
-                              (default is 1000 plus kmer size minus 1)
-  L=<N>                       (L=) sequence length (number of KMERS in
-                              the sequence)
-                              (default is 1000000)
-  --k=<N>                     (K=) kmer size
-                              (default is 21)
-  --confidence=<probability>  (C=) size of confidence interval
-                              (default is 95%)
-  --seed=<string>             random seed for simulations
+optional arguments:
+  -h, --help            show this help message and exit
+  --sccon SCCON [SCCON ...]
+                        observed MinHash Containment (input one or more values, separated by a space)
+  --length LENGTH       number of nucleotides in the sequence
+  -L NUM_UNIQUE_KMERS, --num-unique-kmers NUM_UNIQUE_KMERS
+                        number of unique k-mers in the sequence
+  --scaled SCALED       scaling factor of the sketch
+  -k KSIZE, --ksize KSIZE
+                        kmer size
+  -c CONFIDENCE, --confidence CONFIDENCE
+                        size of confidence interval, (value between 0 and 1)
+  -s SEED, --seed SEED  random seed for simulations
+  --debug               debug
+  --debug_options [{nocache,nojmonotonicity,nsanity} [{nocache,nojmonotonicity,nsanity} ...]]
+                        Specify one or more debugging options, separated by a space
 ```

--- a/p-from-scaled-containment.py
+++ b/p-from-scaled-containment.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import sys
 from sys  import argv,exit
 from math import ceil
 import kmer_mutation_formulas_thm5 as thm5
@@ -8,82 +9,79 @@ from scipy.optimize import brentq, fsolve, newton
 from scipy.stats import norm as scipy_norm
 from numpy import sqrt
 
+import argparse
+
 try:
 	from mpmath import mp as mpmath,mpf
 	mpmath.dps = 50
 except ModuleNotFoundError:
 	mpf = lambda v:float(v)
 
-def usage(s=None):
-    message = """
-Compute confidence interval for the mutation rate p, given the observed number
-of mutated k-mers.
-
-usage: p-from-scaled-containment.py [options]
-  --sccon=<list>              (Cks=) (cumulative) observed number of mutated
-                              k-mers; <list> is a comma-separated list of
-                              numbers
-  --scale=<probability>       (s=) scaling factor of the hash
-  
-  --length=<N>                (l=) sequence length (number of NUCLEOTIDES in
-                              the sequence)
-                              (default is 1000 plus kmer size minus 1)
-  L=<N>                       (L=) sequence length (number of KMERS in
-                              the sequence)
-                              (default is 1000000)
-  --k=<N>                     (K=) kmer size
-                              (default is 21)
-  --confidence=<probability>  (C=) size of confidence interval
-                              (default is 95%)
-  --seed=<string>             random seed for simulations"""
-  
-    if (s == None): exit (message)
-    else:           exit ("%s\n%s" % (s,message))
-
 
 def probit(p):
     return scipy_norm.ppf(p)
 
+def compute_confidence_intervals(L, k, alpha, s, debug=False):
+    z_alpha = probit(1-alpha/2)
+    f1 = lambda Nm: 1-1.0*Nm/L + z_alpha*sqrt( 1.0*Nm*(L-Nm)*(1-s)/(s * L**3) ) - Cks
+    f1_mpf = lambda Nm: mpf(f1(Nm))
+    f2 = lambda Nm: 1-1.0*Nm/L - z_alpha*sqrt( 1.0*Nm*(L-Nm)*(1-s)/(s * L**3) ) - Cks
+    f2_mpf = lambda Nm: mpf(f2(Nm))
+
+    for (CksIx,Cks) in enumerate(scaledContainmentsObserverved):
+        Nm_guess = L*(1-Cks)
+        sol1_mpf = newton(f1_mpf, Nm_guess)
+        sol2_mpf = newton(f2_mpf, Nm_guess)
+        #if debug:
+            #print( sol1, f1(sol1) )
+             #print( float(sol1_new), float(f1_new(float(sol1_new))) )
+             #print( float(sol1_new), float(f1(sol1_new)) )
+             #print( sol1_mpf, f1_mpf(sol1_mpf) )
+             #print( sol2, f2(sol2) )
+             #print( sol2_mpf, f2_mpf(sol2_mpf) )
+
+        sol1 = sol1_mpf
+        sol2 = sol2_mpf
+
+        Clow = 1-1.0*sol1/L
+        Chigh = 1-1.0*sol2/L
+
+        f3 = lambda pest: mpf((1-pest)**k + z_alpha*sqrt( thm5.var_n_mutated(L,k,pest) ) / L - Clow)
+        f4 = lambda pest: mpf((1-pest)**k - z_alpha*sqrt( thm5.var_n_mutated(L,k,pest) ) / L - Chigh)
+
+        phigh = newton(f3, Clow)
+        plow = newton(f4, Chigh)
+
+        #phigh = brentq(f3, 0.0001, 0.95)
+        #plow = brentq(f4, 0.0001, 0.95)
+
+        #print(phigh, f3(phigh))
+        #print(plow, f4(plow))
+
+        values = [L,k,confidence,Cks,Clow,Chigh,plow,phigh]
+        return values
+
 def main():
     global reportProgress,debug
+
     # parse the command line
-    scaledContainmentsObserverved  = []
-    scaleFactor        = 0.1 #default 
-    ntSequenceLength   = None
-    kmerSequenceLength = None
-    kmerSize           = 21
-    confidence         = 0.95
-    prngSeed           = None
-    debug              = []
-    for arg in argv[1:]:
-        if ("=" in arg):
-            argVal = arg.split("=",1)[1]
-        if (arg in ["--help","-help","--h","-h"]):
-            usage()
-        elif (arg.lower().startswith("--sccon=")) or (arg.upper().startswith("Cs=")):
-            scaledContainmentsObserverved += list(map(parse_probability,argVal.split(",")))
-        elif (arg.startswith("--length=")) or (arg.startswith("l=")):
-            ntSequenceLength = int_with_unit(argVal)
-        elif (arg.startswith("--scale=")) or (arg.startswith("s=")):
-            scaleFactor = parse_probability(argVal)
-        elif(arg.startswith("L=")):
-            kmerSequenceLength = int_with_unit(argVal)
-        elif (arg.startswith("--kmer=")) or (arg.upper().startswith("K=")):
-            kmerSize = int(argVal)
-        elif (arg.startswith("--confidence=")) or (arg.startswith("C=")):
-            confidence = parse_probability(argVal)
-        elif (arg.startswith("--seed=")):
-            prngSeed = argVal
-        elif (arg == "--debug"):
-            debug += ["debug"]
-        elif (arg.startswith("--debug=")):
-            debug += argVal.split(",")
-        elif (arg.startswith("--")):
-            usage("unrecognized option: %s" % arg)
-        else:
-            usage("unrecognized option: %s" % arg)
-    if (scaledContainmentsObserverved == []):
-        usage("you have to give me at least one scaled containment observation")
+
+    scaledContainmentsObserverved += list(map(parse_probability, args.sccon))
+    if args.length:
+        ntSequenceLength = int_with_unit(args.length)
+    if args.num_unique_kmers:
+        kmerSequenceLength = int_with_unit(args.num_unique_kmers)
+    kmerSize = args.ksize
+    scaleFactor = parse_probability(args.scaled)
+    confidence = parse_probability(args.confidence)
+    prngSeed = args.seed # not used anywhere?
+    debug = []
+    if args.debug:
+        debug = ["debug"]
+    if args.debug_options:
+       debug += args.debug_options
+
+    # check for necessary info
     if (ntSequenceLength != None) and (kmerSequenceLength != None):
         if (kmerSequenceLength != ntSequenceLength + kmerSize-1):
             usage("nucleotide and kmer sequence lengths are inconsistent\nyou only need to specify one of them")
@@ -91,6 +89,8 @@ def main():
         ntSequenceLength = kmerSequenceLength + (kmerSize-1)
     elif (ntSequenceLength == None):
         ntSequenceLength = 100000 + (kmerSize-1)
+
+    # handle debugging options:
     if ("nocache" in debug):
         hgslicer.useCache = False
     if ("nojmonotonicity" in debug):
@@ -100,55 +100,21 @@ def main():
     if ("nsanity" in debug):
         hgslicer.doNLowSanityCheck  = True
         hgslicer.doNHighSanityCheck = True
-	
+
+
     # compute the confidence interval(s)
     L = ntSequenceLength - (kmerSize-1)
     k = kmerSize
     alpha = 1 - confidence
     s = scaleFactor
-    
+    conf_intervals = compute_confidence_intervals(L,k,alpha,s)
+
+    #write results
     header = ["L","k","conf","Cks","CLow","CHigh","pLow","pHigh"]
     print("\t".join(header))
-    z_alpha = probit(1-alpha/2)
-    f1 = lambda Nm: 1-1.0*Nm/L + z_alpha*sqrt( 1.0*Nm*(L-Nm)*(1-s)/(s * L**3) ) - Cks
-    f1_mpf = lambda Nm: mpf(f1(Nm))
-    f2 = lambda Nm: 1-1.0*Nm/L - z_alpha*sqrt( 1.0*Nm*(L-Nm)*(1-s)/(s * L**3) ) - Cks
-    f2_mpf = lambda Nm: mpf(f2(Nm))
-    
-    for (CksIx,Cks) in enumerate(scaledContainmentsObserverved):
-        Nm_guess = L*(1-Cks)
-        sol1_mpf = newton(f1_mpf, Nm_guess)
-        sol2_mpf = newton(f2_mpf, Nm_guess)
-        
-        #print( sol1, f1(sol1) )
-        #print( float(sol1_new), float(f1_new(float(sol1_new))) )
-        #print( float(sol1_new), float(f1(sol1_new)) )
-        #print( sol1_mpf, f1_mpf(sol1_mpf) )
-        #print( sol2, f2(sol2) )
-        #print( sol2_mpf, f2_mpf(sol2_mpf) )
-        
-        sol1 = sol1_mpf
-        sol2 = sol2_mpf
-        
-        Clow = 1-1.0*sol1/L
-        Chigh = 1-1.0*sol2/L
-        
-        f3 = lambda pest: mpf((1-pest)**k + z_alpha*sqrt( thm5.var_n_mutated(L,k,pest) ) / L - Clow)
-        f4 = lambda pest: mpf((1-pest)**k - z_alpha*sqrt( thm5.var_n_mutated(L,k,pest) ) / L - Chigh)
-        
-        phigh = newton(f3, Clow)
-        plow = newton(f4, Chigh)
-        
-        #phigh = brentq(f3, 0.0001, 0.95)
-        #plow = brentq(f4, 0.0001, 0.95)
-        
-        #print(phigh, f3(phigh))
-        #print(plow, f4(plow))
-        
-        values = [L,k,confidence,Cks,Clow,Chigh,plow,phigh]
-        print("\t".join(str(v)[:7] for v in values))
-        
-            
+    print("\t".join(str(v)[:7] for v in values))
+
+
 # parse_probability--
 #	Parse a string as a probability
 
@@ -190,4 +156,27 @@ def int_with_unit(s):
 	try:               return          int(s)   * multiplier
 	except ValueError: return int(ceil(float(s) * multiplier))
 
-if __name__ == "__main__": main()
+
+
+def cmdline(sys_args):
+    "Command line entry point w/argparse action."
+    p = argparse.ArgumentParser(description="Compute confidence interval for the mutation rate p, given the observed number of mutated k-mers")
+    p.add_argument("--sccon", nargs="+", help="observed number of mutated k-mers", required=True) # at least one observation is required
+
+    # add # nucleotides and the # of unique k-mers as a mutually exclusive group, with one (and only one) required
+    seqlen_info = p.add_mutually_exclusive_group(required=True) #, help="nucleotide and kmer sequence lengths are inconsistent\nyou only need to specify one of them")
+    seqlen_info.add_argument("--length", type=int, help="number of nucleotides in the sequence") #default=1000000
+    seqlen_info.add_argument("-L", "--num-unique-kmers", help="number of unique k-mers in the sequence")
+    # optional arguments
+    p.add_argument("--scaled", type=int, help="scaling factor of the sketch")
+    p.add_argument("-k", "--ksize", type=int, default=21, help="kmer size")
+    p.add_argument("-c", "--confidence", default=0.95, help="size of confidence interval, (value between 0 and 1)") # type=float would constrain to float
+    p.add_argument("-s", "--seed", type=int, help="random seed for simulations")
+    p.add_argument("--debug", action="store_true", help="debug")
+    p.add_argument("--debug_options", nargs="*", help="additional options for debugging ('nocache', 'nojmonotonicity', 'nsanity')")
+    args = p.parse_args()
+    return main(args)
+
+if __name__ == '__main__':
+    returncode = cmdline(sys.argv[1:])
+    sys.exit(returncode)

--- a/p-from-scaled-containment.py
+++ b/p-from-scaled-containment.py
@@ -79,10 +79,10 @@ def main(args):
     confidence = parse_probability(args.confidence)
     prngSeed = args.seed # not used anywhere?
     debug = []
-    if args.debug:
-        debug = ["debug"]
     if args.debug_options:
-       debug += args.debug_options
+       debug = ["debug"] + args.debug_options
+    elif args.debug:
+        debug = ["debug"]
 
     # check for necessary info
     if (ntSequenceLength != None) and (kmerSequenceLength != None):
@@ -168,7 +168,7 @@ def int_with_unit(s):
 def cmdline(sys_args):
     "Command line entry point w/argparse action."
     p = argparse.ArgumentParser(description="Compute confidence interval for the mutation rate p, given the observed number of mutated k-mers")
-    p.add_argument("--sccon", nargs="+", help="observed number of mutated k-mers", required=True) # at least one observation is required
+    p.add_argument("--sccon", nargs="+", help="observed MinHash Containment (input one or more values, separated by a space)", required=True) # at least one observation is required
 
     # add # nucleotides and the # of unique k-mers as a mutually exclusive group, with one (and only one) required
     seqlen_info = p.add_mutually_exclusive_group(required=True) #, help="nucleotide and kmer sequence lengths are inconsistent\nyou only need to specify one of them")
@@ -180,7 +180,8 @@ def cmdline(sys_args):
     p.add_argument("-c", "--confidence", default=0.95, help="size of confidence interval, (value between 0 and 1)") # type=float would constrain to float
     p.add_argument("-s", "--seed", type=int, help="random seed for simulations")
     p.add_argument("--debug", action="store_true", help="debug")
-    p.add_argument("--debug_options", nargs="*", help="additional options for debugging ('nocache', 'nojmonotonicity', 'nsanity')")
+    #p.add_argument("--debug_options", nargs="*", help="additional options for debugging ('nocache', 'nojmonotonicity', 'nsanity'). Enter one or more options (separated by a space)")
+    p.add_argument("--debug_options", nargs="*", choices = ['nocache', 'nojmonotonicity', 'nsanity'], help="Specify one or more debugging options, separated by a space")
     args = p.parse_args()
     return main(args)
 

--- a/p-from-scaled-containment.py
+++ b/p-from-scaled-containment.py
@@ -20,7 +20,8 @@ except ModuleNotFoundError:
 def probit(p):
     return scipy_norm.ppf(p)
 
-def compute_confidence_intervals(scaledContainmentsObserverved, L, k, alpha, s, debug=False):
+def compute_confidence_intervals(scaledContainmentsObserverved, L, k, confidence, s, debug=False):
+    alpha = 1 - confidence
     z_alpha = probit(1-alpha/2)
     f1 = lambda Nm: 1-1.0*Nm/L + z_alpha*sqrt( 1.0*Nm*(L-Nm)*(1-s)/(s * L**3) ) - Cks
     f1_mpf = lambda Nm: mpf(f1(Nm))
@@ -60,7 +61,7 @@ def compute_confidence_intervals(scaledContainmentsObserverved, L, k, alpha, s, 
 
         values = [L,k,confidence,Cks,Clow,Chigh,plow,phigh]
         all_results.append(values)
-    return values
+    return all_results
 
 def main(args):
     global reportProgress,debug
@@ -107,10 +108,7 @@ def main(args):
 
     # compute the confidence interval(s)
     L = ntSequenceLength - (kmerSize-1)
-    k = kmerSize
-    alpha = 1 - confidence
-    s = scaleFactor
-    conf_intervals = compute_confidence_intervals(scaledContainmentsObserverved,L,k,alpha,s)
+    conf_intervals = compute_confidence_intervals(scaledContainmentsObserverved,L,kmerSize,confidence,scaleFactor)
 
     #write results
     header = ["L","k","conf","Cks","CLow","CHigh","pLow","pHigh"]

--- a/p-from-scaled-containment.py
+++ b/p-from-scaled-containment.py
@@ -124,18 +124,21 @@ def main(args):
 
 def parse_probability(s,strict=True):
     scale = 1.0
-    if (s.endswith("%")):
-        scale = 0.01
-        s = s[:-1]
-    try:
-        p = float(s)
-    except:
+    if not isinstance(s, float):
+        if (s.endswith("%")):
+            scale = 0.01
+            s = s[:-1]
         try:
-            (numer,denom) = s.split("/",1)
-            p = float(numer)/float(denom)
+            p = float(s)
         except:
-            raise ValueError
-    p *= scale
+            try:
+                (numer,denom) = s.split("/",1)
+                p = float(numer)/float(denom)
+            except:
+                raise ValueError
+        p *= scale
+    else:
+        p=s
     if (strict) and (not 0.0 <= p <= 1.0):
         raise ValueError
     return p
@@ -172,7 +175,7 @@ def cmdline(sys_args):
     seqlen_info.add_argument("--length", type=int, help="number of nucleotides in the sequence") #default=1000000
     seqlen_info.add_argument("-L", "--num-unique-kmers", help="number of unique k-mers in the sequence")
     # optional arguments
-    p.add_argument("--scaled", help="scaling factor of the sketch", required=True)
+    p.add_argument("--scaled", help="scaling factor of the sketch", default=0.1)
     p.add_argument("-k", "--ksize", type=int, default=21, help="kmer size")
     p.add_argument("-c", "--confidence", default=0.95, help="size of confidence interval, (value between 0 and 1)") # type=float would constrain to float
     p.add_argument("-s", "--seed", type=int, help="random seed for simulations")


### PR DESCRIPTION
Hi folks,

I wanted to be able to estimate the confidence interval within python, rather than needing to run the full script on the command line. To facilitate this, I pulled the main estimation functionality into a function called `compute_confidence_intervals`.

I also replaced manual argument parsing with python's `argparse` module. While this constrains how you write the options a bit more, it prevents needing to update both the `usage` and the manual parsing in the case of argument changes, and minimizes the potential for manual parsing errors. Lmk what you think.

I tried to stick as closely as possible to your implementation. The one exception is that `--length` (sequence length) and `-L`/`--num-unique-kmers` are now mutually exclusive: the script requires one and only one to be provided. Unfortunately, this means I can't set a default for either of them. Happy to change this back and do manual checking on these args if you really want a default.