### PR TITLE
updated solvers to brentq

### DIFF
--- a/mrcc/p_from_scaled_containment.py
+++ b/mrcc/p_from_scaled_containment.py
@@ -49,11 +49,11 @@ def compute_confidence_intervals(scaledContainmentsObserverved, L, k, confidence
         f3 = lambda pest: mpf((1-pest)**k + z_alpha*sqrt( thm5.var_n_mutated(L,k,pest) ) / L - Clow)
         f4 = lambda pest: mpf((1-pest)**k - z_alpha*sqrt( thm5.var_n_mutated(L,k,pest) ) / L - Chigh)
 
-        phigh = newton(f3, Clow)
-        plow = newton(f4, Chigh)
+        #phigh = newton(f3, Clow)
+        #plow = newton(f4, Chigh)
 
-        #phigh = brentq(f3, 0.0001, 0.95)
-        #plow = brentq(f4, 0.0001, 0.95)
+        phigh = brentq(f3, 0.01, 0.99)
+        plow = brentq(f4, 0.01, 0.99)
 
         #print(phigh, f3(phigh))
         #print(plow, f4(plow))


### PR DESCRIPTION
Updated solvers to scipy.brentq so that p is not negative. endpoints of brentq are 0.01 and 0.99. Need to theoretically prove that f3(0.01) >0 and f3(0.99) < 0. The same should hold for f4